### PR TITLE
Attempt to update the library first day of the month

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -3,7 +3,7 @@ name: Auto Update
 on:
     workflow_dispatch:
     schedule:
-        -   cron: '0 0 * * 0'
+        -   cron: '0 0 1 * *'
 
 defaults:
     run:


### PR DESCRIPTION
Change the auto update script to attempt an update once a month rather than once a week. If there's a specific icon that someone would like to use, we can update the package manually.